### PR TITLE
Fix chgres_cube build on hera

### DIFF
--- a/modulefiles/chgres_cube.hera
+++ b/modulefiles/chgres_cube.hera
@@ -11,7 +11,7 @@ module load esmf/8.0.0bs21
 
 module use -a /scratch2/NCEPDEV/nwprod/NCEPLIBS/modulefiles
 module load w3nco
-module load nemsio/2.2.3
+module load nemsio/2.2.4
 module load bacio
 module load sp
 module load sfcio


### PR DESCRIPTION
- Change module nemsio/2.2.3 to nemsio/2.2.4 to build chgres_cube on hera.