### PR TITLE
Update old module loads for netcdf and hdf5 for fre-nctools build on Jet

### DIFF
--- a/modulefiles/fv3gfs/fre-nctools.jet
+++ b/modulefiles/fv3gfs/fre-nctools.jet
@@ -1,8 +1,8 @@
 #%Module#####################################################
 ## Module file for fre-nctools
 #############################################################
-module load intel/15.0.3.187
-module load impi/5.0.3.048  
+module load intel/18.0.5.274
+module load impi/2018.4.274
 module load szip/2.1
-module load hdf5/1.8.9
-module load netcdf/4.2.1.1
+module load netcdf/4.7.0
+module load hdf5/1.10.5

--- a/modulefiles/fv3gfs/orog.jet
+++ b/modulefiles/fv3gfs/orog.jet
@@ -1,17 +1,16 @@
 #%Module#####################################################
 ## Module file for orog
 #############################################################
-# Loading Intel Compiler Suite
-#
 module purge
-
+# Loading Intel Compiler Suite
 module load intel/18.0.5.274
-module load szip/2.1
-module load hdf5/1.8.9
-module load netcdf/4.2.1.1
 
-# Loding nceplibs modules
-module load ip/v2.0.0
+module load netcdf/4.7.0
+module load szip/2.1
+module load hdf5/1.10.5
+
+# Loading nceplibs modules
+module load ip/v3.0.1
 module load sp/v2.0.2
 module load w3emc/v2.3.0
 module load w3nco/v2.0.6


### PR DESCRIPTION
The build has been tested and works.

@gsketefian 
@jwolff-ncar 
@JulieSchramm 
@mkavulich 
@panll 
@llpcarson 