### PR TITLE
Revert feature/chgres_grib2 to state prior to wind field errors

### DIFF
--- a/modulefiles/chgres_cube.jet
+++ b/modulefiles/chgres_cube.jet
@@ -8,7 +8,7 @@ module load intel/18.0.5.274
 module load impi/2018.4.274
 module load szip
 module load hdf5/1.10.4
-module load netcdf/4.2.1.1
+module load netcdf/4.6.1
 
 #module load esmflocal/ESMF_8_0_0_beta_snapshot_21
 

--- a/sorc/chgres_cube.fd/input_data.F90
+++ b/sorc/chgres_cube.fd/input_data.F90
@@ -4647,8 +4647,6 @@ if (localpet == 0) then
        endif
        print*, "CLOSE GEOGRID FILE "
        iret = nf90_close(ncid2d)
-     else
-     call error_handler("COULD NOT FIND GEOGRID FILE. PLEASE CHECK PATH. EXITING.")
      endif
    endif
    


### PR DESCRIPTION
See issue: https://github.com/NOAA-EMC/UFS_UTILS/issues/93

This reverts the merge in PR #33 
