### PR TITLE
Add ability to have any character as the separator between $CRES and "mosaic" in the name of the mosaic file

### DIFF
--- a/sorc/chgres_cube.fd/program_setup.f90
+++ b/sorc/chgres_cube.fd/program_setup.f90
@@ -228,6 +228,11 @@
 
  is = index(mosaic_file_target_grid, "/", back=.true.)
  ie = index(mosaic_file_target_grid, "_mosaic", back=.true.)
+! Allow any character (not just underscore, but for example a period) to
+! be the separator between $CRES and "mosaic".
+! ie = index(mosaic_file_target_grid, "_mosaic", back=.true.)
+ ie = index(mosaic_file_target_grid, "mosaic", back=.true.)
+ ie = ie - 1
 
  if (is == 0 .or. ie == 0) then
    call error_handler("CANT DETERMINE CRES FROM MOSAIC FILE.", 1)


### PR DESCRIPTION
Small change to be able to specify a mosaic file named, for example, C768.mosaic.nc instead of only being able to have an underscore after the C768 (C768_mosaic.nc). This is so that we can use the same file naming convention for mosaic files as for surface climatology files (which use a dot, not an underscore, after $CRES).

Tested on hera.