### PR TITLE
Cheyenne modulefile fix

### DIFF
--- a/modulefiles/fv3gfs/orog.cheyenne
+++ b/modulefiles/fv3gfs/orog.cheyenne
@@ -11,3 +11,6 @@ module load netcdf/4.6.3
 # Loding nceplibs modules
 module use -a /glade/p/ral/jntp/GMTB/tools/modulefiles/intel-19.0.2/impi-2019.2.187
 module load NCEPlibs/9.9.9
+
+# Point to libip_d.a until Dom can include this in module load
+setenv IP_LIBd /glade/p/ral/jntp/GMTB/tools/NCEPlibs/20190703/intel-19.0.2/impi-2019.2.187/lib/libip_d.a

--- a/modulefiles/fv3gfs/orog.cheyenne
+++ b/modulefiles/fv3gfs/orog.cheyenne
@@ -12,5 +12,3 @@ module load netcdf/4.6.3
 module use -a /glade/p/ral/jntp/GMTB/tools/modulefiles/intel-19.0.2/impi-2019.2.187
 module load NCEPlibs/9.9.9
 
-# Point to libip_d.a until Dom can include this in module load
-setenv IP_LIBd /glade/p/ral/jntp/GMTB/tools/NCEPlibs/20190703/intel-19.0.2/impi-2019.2.187/lib/libip_d.a

--- a/modulefiles/fv3gfs/orog.cheyenne
+++ b/modulefiles/fv3gfs/orog.cheyenne
@@ -11,6 +11,3 @@ module load netcdf/4.6.3
 # Loding nceplibs modules
 module use -a /glade/p/ral/jntp/GMTB/tools/modulefiles/intel-19.0.2/impi-2019.2.187
 module load NCEPlibs/9.9.9
-
-# Point to libip_d.a until Dom can include this in module load
-export IP_LIBd=/glade/p/ral/jntp/GMTB/tools/NCEPlibs/20190703/intel-19.0.2/impi-2019.2.187/lib/libip_d.a

--- a/sorc/build_orog.sh
+++ b/sorc/build_orog.sh
@@ -9,15 +9,18 @@ source ./machine-setup.sh > /dev/null 2>&1
 cwd=`pwd`
 
 USE_PREINST_LIBS=${USE_PREINST_LIBS:-"true"}
+module use -a ../modulefiles/fv3gfs
 if [ $USE_PREINST_LIBS = true ]; then
   export MOD_PATH
-  source ../modulefiles/fv3gfs/orog.$target             > /dev/null 2>&1
+  module use -a ../modulefiles/fv3gfs
+  module load orog.$target             > /dev/null 2>&1
 else
   export MOD_PATH=${cwd}/lib/modulefiles
   if [ $target = wcoss_cray ]; then
     source ../modulefiles/fv3gfs/orog.${target}_userlib > /dev/null 2>&1
   else
-    source ../modulefiles/fv3gfs/orog.$target           > /dev/null 2>&1
+    module use -a ../modulefiles/fv3gfs
+    module load orog.$target           > /dev/null 2>&1
   fi
 fi
 


### PR DESCRIPTION
The regional workflow pull request #236 (https://github.com/NOAA-EMC/regional_workflow/pull/236/files) will cause the regional_workflow to load the modulefiles in this repository at runtime rather than keeping a separate copy there. Before that happens a few fixes are needed for Cheyenne, which are contained in this PR.

This PR will change the orog.cheyenne modulefile to use proper modulefile syntax for setting environment variables, and will modify the build_orog.sh script  (which is used in the build for the srweather-app for now) to properly load the modulefiles rather than loading them as shell scripts.

This has been tested on Cheyenne and confirmed to work in the srweather-app/regional_workflow when combined with the above regional_workflow PR (ran the end-to-end workflow successfully for the GSD_HRRR25km predefined domain). Will test on Hera and Jet shortly. 

Note: I kept the old method in place for wcoss machines because I have no way to test those changes. I also did not touch any other utilities because this is a somewhat urgent fix, but we should consider taking a similar approach for all utilities in this repository soon.