### PR TITLE
Fixes for modulefile orog.hera

### DIFF
--- a/modulefiles/fv3gfs/orog.hera
+++ b/modulefiles/fv3gfs/orog.hera
@@ -13,3 +13,4 @@ module load sp/2.0.2
 module load w3emc/2.3.0
 module load w3nco/2.0.6
 module load bacio/2.0.2
+module load hdf5/1.10.5

--- a/modulefiles/fv3gfs/orog.hera
+++ b/modulefiles/fv3gfs/orog.hera
@@ -7,7 +7,7 @@ module load intel/18.0.5.274
 module load netcdf/4.7.0
 
 # Loding nceplibs modules
-module use -a /lfs3/projects/hfv3gfs/nwprod/NCEPLIBS/modulefiles
+module use -a /scratch2/NCEPDEV/nwprod/NCEPLIBS/modulefiles
 module load ip/3.0.1
 module load sp/2.0.2
 module load w3emc/2.3.0


### PR DESCRIPTION
1. MOD_PATH needs to be set explicitly so it can be used at runtime as well as during the build.
2. hdf5 must be loaded for runtime success on hera