### PR TITLE
Feature/dtc develop odinstampede

### DIFF
--- a/modulefiles/fv3gfs/fre-nctools.odin
+++ b/modulefiles/fv3gfs/fre-nctools.odin
@@ -1,0 +1,16 @@
+#%Module#####################################################
+## Module file for fre-nctools
+#############################################################
+
+unset LD_LIBRARY_PATH
+
+module load PrgEnv-intel
+module swap intel/19.0.5.281
+module load cray-mpich/7.7.10
+module load cray-libsci
+module load cray-netcdf-hdf5parallel
+module load cray-parallel-netcdf
+module load cray-hdf5-parallel
+
+export NETCDF=/opt/cray/pe/netcdf-hdf5parallel/4.6.3.2/INTEL/19.0
+export HDF5=/opt/cray/pe/hdf5-parallel/1.10.5.2/INTEL/19.0

--- a/modulefiles/fv3gfs/fre-nctools.stampede
+++ b/modulefiles/fv3gfs/fre-nctools.stampede
@@ -1,0 +1,12 @@
+#%Module#####################################################
+## Module file for fre-nctools
+#############################################################
+#
+module purge
+module load intel/18.0.2
+module load impi/18.0.2
+module load netcdf/4.6.2
+module load hdf5/1.10.4
+
+#setenv  NETCDF ${TACC_NETCDF_DIR}
+#setenv  HDF5 /opt/apps/intel18/hdf5/1.10.4/x86_64

--- a/modulefiles/fv3gfs/orog.odin
+++ b/modulefiles/fv3gfs/orog.odin
@@ -1,0 +1,22 @@
+#%Module#####################################################
+## Module file for orog
+#############################################################
+
+module load PrgEnv-intel
+module swap intel/19.0.5.281
+module load cray-mpich/7.7.10
+module load cray-libsci
+module load cray-netcdf-hdf5parallel
+module load cray-parallel-netcdf
+module load cray-hdf5-parallel
+
+#export NETCDF=/opt/cray/pe/netcdf-hdf5parallel/4.6.3.2/INTEL/19.0
+
+module use /oldscratch/ywang/external/modulefiles
+
+# Loading nceplibs modules
+module load ip/v3.0.0
+module load sp/v2.0.2
+module load w3emc/v2.3.0
+module load w3nco/v2.0.6
+module load bacio/v2.0.2

--- a/modulefiles/fv3gfs/orog.stampede
+++ b/modulefiles/fv3gfs/orog.stampede
@@ -1,0 +1,17 @@
+#%Module#####################################################
+## Module file for orog
+#############################################################
+module purge
+# Loading Intel Compiler Suite
+module load intel/18.0.2
+
+module load netcdf/4.6.2
+module load hdf5/1.10.4
+
+# Loading nceplibs modules
+module use /work/00315/tg455890/stampede2/external/modulefiles
+module load ip/v3.0.0
+module load sp/v2.0.2
+module load w3emc/v2.3.0
+module load w3nco/v2.0.6
+module load bacio/v2.0.2

--- a/modulefiles/module_nemsutil.odin
+++ b/modulefiles/module_nemsutil.odin
@@ -1,0 +1,23 @@
+#%Module#####################################################
+## Module file for nemsutil
+#############################################################
+
+# Loading Intel Compiler Suite
+
+unset LD_LIBRARY_PATH
+
+module load PrgEnv-intel
+module swap intel/19.0.5.281
+module load cray-mpich/7.7.10
+module load cray-libsci
+module load cray-netcdf-hdf5parallel
+module load cray-parallel-netcdf
+module load cray-hdf5-parallel
+
+# Loding nceplibs modules
+module use /oldscratch/ywang/external/modulefiles
+module load w3nco/v2.0.6
+module load bacio/v2.0.2
+module load nemsio/v2.2.2
+
+export FCMP=ftn

--- a/modulefiles/modulefile.sfc_climo_gen.odin
+++ b/modulefiles/modulefile.sfc_climo_gen.odin
@@ -1,0 +1,25 @@
+#%Module#####################################################
+## Module file for sfc_climo_gen
+#############################################################
+
+#unset LD_LIBRARY_PATH
+
+module load craype/2.6.2
+module load craype-ivybridge
+module load PrgEnv-intel
+module swap intel/19.0.5.281
+module load cray-mpich/7.7.10
+module load cray-libsci
+module load cray-netcdf-hdf5parallel
+module load cray-parallel-netcdf
+module load cray-hdf5-parallel
+
+export NETCDF=/opt/cray/pe/netcdf-hdf5parallel/4.6.3.2/INTEL/19.0
+export HDF5=/opt/cray/pe/hdf5-parallel/1.10.5.2/INTEL/19.0
+
+module use -a /oldscratch/ywang/external/modulefiles
+
+module load esmf/8.0.0
+
+export FCOMP=ftn
+export FFLAGS="-O3 -fp-model=precise -g -traceback -r8 -i4 -convert big_endian -I${NETCDF}/include"

--- a/modulefiles/modulefile.sfc_climo_gen.stampede
+++ b/modulefiles/modulefile.sfc_climo_gen.stampede
@@ -1,0 +1,21 @@
+#%Module#####################################################
+## Module file for sfc_climo_gen
+#############################################################
+
+module purge
+# Loading Intel Compiler Suite
+module load intel/18.0.2
+module load impi/18.0.2
+#module load netcdf/4.6.2
+#module load hdf5/1.10.4
+module load parallel-netcdf/4.6.2
+module load phdf5
+
+module load python3
+
+# Loading nceplibs modules
+module use /work/00315/tg455890/stampede2/external/modulefiles
+module load esmf/8.0.0
+
+export FCOMP=mpiifort
+export FFLAGS="-O3 -fp-model=precise -g -traceback -r8 -i4 -convert big_endian"

--- a/sorc/build_fre-nctools.sh
+++ b/sorc/build_fre-nctools.sh
@@ -52,6 +52,11 @@ elif [ $system_site = "cheyenne" ]; then
   NETCDF_DIR=$NETCDF
   HDF5_DIR=$NETCDF        #HDF5 resides with NETCDF on Cheyenne
   export HDF5=$NETCDF     #HDF5 used in Makefile_cheyenne
+elif [ $system_site = "stampede" ]; then
+  NETCDF_DIR=$TACC_NETCDF_DIR
+  NETCDF=${TACC_NETCDF_DIR}
+  HDF5_DIR=$TACC_HDF5_DIR
+  export HDF5=$TACC_HDF5_DIR
 fi
 
 #

--- a/sorc/build_orog.sh
+++ b/sorc/build_orog.sh
@@ -54,6 +54,10 @@ elif [ $target = cheyenne ]; then
  INCS="-I${NETCDF}/include"
  export LIBSM="${BACIO_LIB4} ${W3NCO_LIBd} ${IP_LIBd} ${SP_LIBd} -L${NETCDF}/lib -lnetcdff -lnetcdf"
  export FFLAGSM="-O3 -g -traceback -r8  -convert big_endian -fp-model precise  -assume byterecl ${INCS}"
+elif [ $target = odin ]; then
+ INCS="-I${NETCDF}/include"
+ export LIBSM="${BACIO_LIB4} ${W3NCO_LIBd} ${IP_LIBd} ${SP_LIBd} -L${NETCDF}/lib -lnetcdff -lnetcdf"
+ export FFLAGSM="-O3 -g -traceback -r8  -convert big_endian -fp-model precise  -assume byterecl ${INCS}"
 else
  echo machine $target not found
  exit 1

--- a/sorc/build_orog.sh
+++ b/sorc/build_orog.sh
@@ -58,6 +58,10 @@ elif [ $target = odin ]; then
  INCS="-I${NETCDF}/include"
  export LIBSM="${BACIO_LIB4} ${W3NCO_LIBd} ${IP_LIBd} ${SP_LIBd} -L${NETCDF}/lib -lnetcdff -lnetcdf"
  export FFLAGSM="-O3 -g -traceback -r8  -convert big_endian -fp-model precise  -assume byterecl ${INCS}"
+elif [ $target = stampede ]; then
+ INCS="-I${TACC_NETCDF_DIR}/include"
+ export LIBSM="${BACIO_LIB4} ${W3NCO_LIBd} ${IP_LIBd} ${SP_LIBd} -L${TACC_NETCDF_DIR}/lib -lnetcdff -lnetcdf"
+ export FFLAGSM="-O3 -g -traceback -r8  -convert big_endian -fp-model precise  -assume byterecl ${INCS}"
 else
  echo machine $target not found
  exit 1

--- a/sorc/build_sfc_climo_gen.sh
+++ b/sorc/build_sfc_climo_gen.sh
@@ -10,6 +10,7 @@ if [ ! -d "../exec" ]; then
 fi
 
 module purge
+
 USE_PREINST_LIBS=${USE_PREINST_LIBS:-"true"}
 if [ $USE_PREINST_LIBS = true ]; then
   export MOD_PATH

--- a/sorc/fre-nctools.fd/tools/filter_topo/make.csh_odin
+++ b/sorc/fre-nctools.fd/tools/filter_topo/make.csh_odin
@@ -1,0 +1,6 @@
+#!/bin/sh -f
+
+source $MODULESHOME/init/sh
+source ${PWD}/../../../../modulefiles/fv3gfs/fre-nctools.odin
+
+ftn -o filter_topo -I${NETCDF}/include -fltconsistency -fno-alias -stack_temps -safe_cray_ptr -ftz -assume byterecl -g -O2 -i4 -real_size 64 -traceback filter_topo.F90 -L${NETCDF}/lib -L${HDF5}/lib -lnetcdf -lnetcdff -lhdf5_hl -lhdf5

--- a/sorc/fre-nctools.fd/tools/filter_topo/make.csh_stampede
+++ b/sorc/fre-nctools.fd/tools/filter_topo/make.csh_stampede
@@ -1,0 +1,8 @@
+#!/bin/sh -f
+
+source $MODULESHOME/init/sh
+source ${PWD}/../../../../modulefiles/fv3gfs/fre-nctools.stampede
+
+export NETCDF=${TACC_NETCDF_DIR}
+
+mpiifort -o filter_topo -I${NETCDF}/include -fltconsistency -fno-alias -stack_temps -safe_cray_ptr -ftz -assume byterecl -g -O2 -i4 -real_size 64 -traceback filter_topo.F90 -L${NETCDF}/lib -L${HDF5}/lib -lnetcdf -lnetcdff -lhdf5_hl -lhdf5

--- a/sorc/fre-nctools.fd/tools/fregrid/env.odin
+++ b/sorc/fre-nctools.fd/tools/fregrid/env.odin
@@ -1,0 +1,4 @@
+# jet 
+MPICC    := cc
+CC       := icc
+STATIC   :=

--- a/sorc/fre-nctools.fd/tools/fregrid/env.stampede
+++ b/sorc/fre-nctools.fd/tools/fregrid/env.stampede
@@ -1,0 +1,4 @@
+# jet 
+MPICC    := mpiicc
+CC       := icc
+STATIC   :=

--- a/sorc/fre-nctools.fd/tools/fregrid/fre-nctools.mk_odin
+++ b/sorc/fre-nctools.fd/tools/fregrid/fre-nctools.mk_odin
@@ -1,0 +1,90 @@
+#
+# $Id: fre-nctools.mk,v 20.0 2013/12/14 00:32:02 fms Exp $
+# ------------------------------------------------------------------------------
+# FMS/FRE Project: Makefile to Build Regridding Executables
+# ------------------------------------------------------------------------------
+# afy    Ver   1.00  Initial version (Makefile, ver 17.0.4.2)       June 10
+# afy    Ver   1.01  Add rules to build MPI-based executable        June 10
+# afy    Ver   1.02  Simplified according to fre-nctools standards  June 10
+# ------------------------------------------------------------------------------
+# Copyright (C) NOAA Geophysical Fluid Dynamics Laboratory, 2009-2010
+# Designed and written by V. Balaji, Amy Langenhorst and Aleksey Yakovlev
+#
+# MPICC and CC are defined in env.$(SITE)
+include ./env.$(SITE)
+
+#MPICC    := mpicc
+#CC       := icc
+CFLAGS   := -O3 -g
+CFLAGS_O2:= -O2 -g
+INCLUDES := -I${NETCDF_HOME}/include -I./ -I../shared -I../../shared/mosaic
+CLIBS     := -L${NETCDF_HOME}/lib -L${HDF5_HOME}/lib -lnetcdf -lhdf5_hl -lhdf5 -limf $(CLIBS2) $(STATIC)
+
+TARGETS  := fregrid fregrid_parallel
+
+SOURCES  := fregrid.c bilinear_interp.c conserve_interp.c fregrid_util.c
+SOURCES  += create_xgrid.c gradient_c2l.c interp.c read_mosaic.c
+SOURCES  += mpp_domain.c mpp_io.c tool_util.c affinity.c
+
+OBJECTS  := $(SOURCES:c=o)
+
+HEADERS = fre-nctools.mk ../shared/mpp.h  ../shared/mpp_domain.h  ../shared/mpp_io.h ../shared/tool_util.h   \
+          ../../shared/mosaic/constant.h ../../shared/mosaic/create_xgrid.h  \
+          ../../shared/mosaic/gradient_c2l.h ../../shared/mosaic/interp.h  \
+          ../../shared/mosaic/mosaic_util.h  ../../shared/mosaic/read_mosaic.h 
+
+all: $(TARGETS)
+
+fregrid: $(OBJECTS) mosaic_util.o mpp.o
+	$(CC) -o $@ $^ $(CLIBS)
+
+fregrid_parallel: $(OBJECTS) mosaic_util_parallel.o mpp_parallel.o
+	$(MPICC) -o $@ $^ $(CLIBS)
+
+mosaic_util.o: ../../shared/mosaic/mosaic_util.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -c $< 
+
+mosaic_util_parallel.o: ../../shared/mosaic/mosaic_util.c $(HEADERS)
+	$(MPICC) -Duse_libMPI $(CFLAGS) $(INCLUDES) -o $@ -c $< 
+
+read_mosaic.o: ../../shared/mosaic/read_mosaic.c $(HEADERS)
+	$(CC) -Duse_netCDF $(CFLAGS) $(INCLUDES) -c $< 
+
+gradient_c2l.o: ../../shared/mosaic/gradient_c2l.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -c $< 
+
+interp.o: ../../shared/mosaic/interp.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -c $< 
+
+mpp_io.o: ../shared/mpp_io.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ -c $< 
+
+mpp_domain.o: ../shared/mpp_domain.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ -c $< 
+
+affinity.o: ../shared/affinity.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ -c $< 
+
+mpp.o: ../shared/mpp.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ -c $< 
+
+mpp_parallel.o: ../shared/mpp.c $(HEADERS)
+	$(MPICC) -Duse_libMPI $(CFLAGS) $(INCLUDES) -o $@ -c $< 
+
+tool_util.o: ../shared/tool_util.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ -c $< 
+
+conserve_interp.o: conserve_interp.c $(HEADERS)
+	$(CC) $(CFLAGS_O2) $(INCLUDES) -c $< 
+
+bilinear_interp.o: bilinear_interp.c $(HEADERS)
+	$(CC) $(CFLAGS_O2) $(INCLUDES) -c $< 
+
+create_xgrid.o: ../../shared/mosaic/create_xgrid.c $(HEADERS)
+	$(CC) $(CFLAGS_O2) $(INCLUDES) -c $< 
+
+%.o: %.c
+	$(CC) $(CFLAGS) $(INCLUDES) -c $<
+
+clean:
+	-rm -f *.o $(TARGETS)

--- a/sorc/fre-nctools.fd/tools/fregrid/fre-nctools.mk_stampede
+++ b/sorc/fre-nctools.fd/tools/fregrid/fre-nctools.mk_stampede
@@ -1,0 +1,90 @@
+#
+# $Id: fre-nctools.mk,v 20.0 2013/12/14 00:32:02 fms Exp $
+# ------------------------------------------------------------------------------
+# FMS/FRE Project: Makefile to Build Regridding Executables
+# ------------------------------------------------------------------------------
+# afy    Ver   1.00  Initial version (Makefile, ver 17.0.4.2)       June 10
+# afy    Ver   1.01  Add rules to build MPI-based executable        June 10
+# afy    Ver   1.02  Simplified according to fre-nctools standards  June 10
+# ------------------------------------------------------------------------------
+# Copyright (C) NOAA Geophysical Fluid Dynamics Laboratory, 2009-2010
+# Designed and written by V. Balaji, Amy Langenhorst and Aleksey Yakovlev
+#
+# MPICC and CC are defined in env.$(SITE)
+include ./env.$(SITE)
+
+#MPICC    := mpicc
+#CC       := icc
+CFLAGS   := -O3 -g
+CFLAGS_O2:= -O2 -g
+INCLUDES := -I${NETCDF_HOME}/include -I./ -I../shared -I../../shared/mosaic
+CLIBS     := -L${NETCDF_HOME}/lib -L${HDF5_HOME}/lib -lnetcdf -lhdf5_hl -lhdf5 -limf $(CLIBS2) $(STATIC)
+
+TARGETS  := fregrid fregrid_parallel
+
+SOURCES  := fregrid.c bilinear_interp.c conserve_interp.c fregrid_util.c
+SOURCES  += create_xgrid.c gradient_c2l.c interp.c read_mosaic.c
+SOURCES  += mpp_domain.c mpp_io.c tool_util.c affinity.c
+
+OBJECTS  := $(SOURCES:c=o)
+
+HEADERS = fre-nctools.mk ../shared/mpp.h  ../shared/mpp_domain.h  ../shared/mpp_io.h ../shared/tool_util.h   \
+          ../../shared/mosaic/constant.h ../../shared/mosaic/create_xgrid.h  \
+          ../../shared/mosaic/gradient_c2l.h ../../shared/mosaic/interp.h  \
+          ../../shared/mosaic/mosaic_util.h  ../../shared/mosaic/read_mosaic.h 
+
+all: $(TARGETS)
+
+fregrid: $(OBJECTS) mosaic_util.o mpp.o
+	$(CC) -o $@ $^ $(CLIBS)
+
+fregrid_parallel: $(OBJECTS) mosaic_util_parallel.o mpp_parallel.o
+	$(MPICC) -o $@ $^ $(CLIBS)
+
+mosaic_util.o: ../../shared/mosaic/mosaic_util.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -c $< 
+
+mosaic_util_parallel.o: ../../shared/mosaic/mosaic_util.c $(HEADERS)
+	$(MPICC) -Duse_libMPI $(CFLAGS) $(INCLUDES) -o $@ -c $< 
+
+read_mosaic.o: ../../shared/mosaic/read_mosaic.c $(HEADERS)
+	$(CC) -Duse_netCDF $(CFLAGS) $(INCLUDES) -c $< 
+
+gradient_c2l.o: ../../shared/mosaic/gradient_c2l.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -c $< 
+
+interp.o: ../../shared/mosaic/interp.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -c $< 
+
+mpp_io.o: ../shared/mpp_io.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ -c $< 
+
+mpp_domain.o: ../shared/mpp_domain.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ -c $< 
+
+affinity.o: ../shared/affinity.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ -c $< 
+
+mpp.o: ../shared/mpp.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ -c $< 
+
+mpp_parallel.o: ../shared/mpp.c $(HEADERS)
+	$(MPICC) -Duse_libMPI $(CFLAGS) $(INCLUDES) -o $@ -c $< 
+
+tool_util.o: ../shared/tool_util.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ -c $< 
+
+conserve_interp.o: conserve_interp.c $(HEADERS)
+	$(CC) $(CFLAGS_O2) $(INCLUDES) -c $< 
+
+bilinear_interp.o: bilinear_interp.c $(HEADERS)
+	$(CC) $(CFLAGS_O2) $(INCLUDES) -c $< 
+
+create_xgrid.o: ../../shared/mosaic/create_xgrid.c $(HEADERS)
+	$(CC) $(CFLAGS_O2) $(INCLUDES) -c $< 
+
+%.o: %.c
+	$(CC) $(CFLAGS) $(INCLUDES) -c $<
+
+clean:
+	-rm -f *.o $(TARGETS)

--- a/sorc/fre-nctools.fd/tools/make_hgrid/env.odin
+++ b/sorc/fre-nctools.fd/tools/make_hgrid/env.odin
@@ -1,0 +1,7 @@
+CLIBS_SITE  := 
+CFLAGS_SITE := 
+
+# GFDL uses the mpicc wrapper and Intel icc
+MPICC    := cc
+CC       := icc
+NETCDF_HOME = $(NETCDF_DIR)

--- a/sorc/fre-nctools.fd/tools/make_hgrid/env.stampede
+++ b/sorc/fre-nctools.fd/tools/make_hgrid/env.stampede
@@ -1,0 +1,7 @@
+CLIBS_SITE  := 
+CFLAGS_SITE := 
+
+# GFDL uses the mpicc wrapper and Intel icc
+MPICC    := mpiicc
+CC       := icc
+NETCDF_HOME = $(NETCDF_DIR)

--- a/sorc/fre-nctools.fd/tools/make_hgrid/fre-nctools.mk_odin
+++ b/sorc/fre-nctools.fd/tools/make_hgrid/fre-nctools.mk_odin
@@ -1,0 +1,98 @@
+#
+# $Id: fre-nctools.mk,v 20.0 2013/12/14 00:33:28 fms Exp $
+# ------------------------------------------------------------------------------
+# FMS/FRE Project: Makefile to Build Regridding Executables
+# ------------------------------------------------------------------------------
+# afy    Ver   1.00  Initial version (Makefile, ver 17.0.4.2)       June 10
+# afy    Ver   1.01  Add rules to build MPI-based executable        June 10
+# afy    Ver   1.02  Simplified according to fre-nctools standards  June 10
+# ------------------------------------------------------------------------------
+# Copyright (C) NOAA Geophysical Fluid Dynamics Laboratory, 2009-2011
+# This program is distributed under the terms of the GNU General Public
+# License. See the file COPYING contained in this directory
+#
+# Designed and written by V. Balaji, Amy Langenhorst and Aleksey Yakovlev
+#
+include env.$(SITE)
+
+#MPICC    := mpicc
+#CC       := icc
+CFLAGS   := -O3
+CFLAGS_O2:= -O2
+INCLUDES := -I${NETCDF_HOME}/include -I./ -I../shared -I../../shared/mosaic
+CLIBS     := -L${NETCDF_HOME}/lib -L${HDF5_HOME}/lib -lnetcdf -lhdf5_hl -lhdf5 -limf $(CLIBS2) $(STATIC)
+
+TARGETS  := make_hgrid make_hgrid_parallel
+
+SOURCES  := make_hgrid.c create_conformal_cubic_grid.c create_gnomonic_cubic_grid.c create_grid_from_file.c create_lonlat_grid.c
+SOURCES  += mpp_domain.c mpp_io.c tool_util.c
+SOURCES  += read_mosaic.c create_xgrid.c interp.c
+
+OBJECTS  := $(SOURCES:c=o)
+
+HEADERS = fre-nctools.mk ../shared/mpp.h  ../shared/mpp_domain.h  ../shared/mpp_io.h ../shared/tool_util.h   \
+          ../../shared/mosaic/constant.h ../../shared/mosaic/create_xgrid.h  \
+          ../../shared/mosaic/interp.h  ../../shared/mosaic/mosaic_util.h  \
+          ../../shared/mosaic/read_mosaic.h ./create_hgrid.h
+
+all: $(TARGETS)
+
+make_hgrid: $(OBJECTS) mosaic_util.o mpp.o
+	$(CC) -o $@ $^ $(CLIBS)
+
+make_hgrid_parallel: $(OBJECTS) mosaic_util_parallel.o mpp_parallel.o
+	$(MPICC) -o $@ $^ $(CLIBS)
+
+make_hgrid.o: make_hgrid.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -c $< 
+
+create_gnomonic_cubic_grid.o: create_gnomonic_cubic_grid.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -c $< 
+
+create_conformal_cubic_grid.o: create_conformal_cubic_grid.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -c $< 
+
+create_lonlat_grid.o: create_lonlat_grid.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -c $< 
+
+create_grid_from_file.o: create_grid_from_file.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -c $< 
+
+mosaic_util.o: ../../shared/mosaic/mosaic_util.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -c $< 
+
+mosaic_util_parallel.o: ../../shared/mosaic/mosaic_util.c $(HEADERS)
+	$(MPICC) -Duse_libMPI $(CFLAGS) $(INCLUDES) -o $@ -c $< 
+
+read_mosaic.o: ../../shared/mosaic/read_mosaic.c $(HEADERS)
+	$(CC) -Duse_netCDF $(CFLAGS) $(INCLUDES) -c $< 
+
+read_mosaic_parallel.o: ../../shared/mosaic/read_mosaic.c $(HEADERS)
+	$(MPICC) -Duse_libMPI -Duse_netCDF $(CFLAGS) $(INCLUDES) -o $@ -c $< 
+
+interp.o: ../../shared/mosaic/interp.c $(HEADERS)
+	$(CC) -Duse_netCDF $(CFLAGS) $(INCLUDES) -c $< 
+
+mpp_io.o: ../shared/mpp_io.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ -c $< 
+
+mpp_domain.o: ../shared/mpp_domain.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ -c $< 
+
+mpp.o: ../shared/mpp.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ -c $< 
+
+mpp_parallel.o: ../shared/mpp.c $(HEADERS)
+	$(MPICC) -Duse_libMPI $(CFLAGS) $(INCLUDES) -o $@ -c $< 
+
+tool_util.o: ../shared/tool_util.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ -c $< 
+
+create_xgrid.o: ../../shared/mosaic/create_xgrid.c $(HEADERS)
+	$(CC) $(CFLAGS_O2) $(INCLUDES) -c $< 
+
+%.o: %.c
+	$(CC) $(CFLAGS) $(INCLUDES) -c $<
+
+clean:
+	-rm -f *.o $(TARGETS)

--- a/sorc/fre-nctools.fd/tools/make_hgrid/fre-nctools.mk_stampede
+++ b/sorc/fre-nctools.fd/tools/make_hgrid/fre-nctools.mk_stampede
@@ -1,0 +1,98 @@
+#
+# $Id: fre-nctools.mk,v 20.0 2013/12/14 00:33:28 fms Exp $
+# ------------------------------------------------------------------------------
+# FMS/FRE Project: Makefile to Build Regridding Executables
+# ------------------------------------------------------------------------------
+# afy    Ver   1.00  Initial version (Makefile, ver 17.0.4.2)       June 10
+# afy    Ver   1.01  Add rules to build MPI-based executable        June 10
+# afy    Ver   1.02  Simplified according to fre-nctools standards  June 10
+# ------------------------------------------------------------------------------
+# Copyright (C) NOAA Geophysical Fluid Dynamics Laboratory, 2009-2011
+# This program is distributed under the terms of the GNU General Public
+# License. See the file COPYING contained in this directory
+#
+# Designed and written by V. Balaji, Amy Langenhorst and Aleksey Yakovlev
+#
+include env.$(SITE)
+
+#MPICC    := mpicc
+#CC       := icc
+CFLAGS   := -O3
+CFLAGS_O2:= -O2
+INCLUDES := -I${NETCDF_HOME}/include -I./ -I../shared -I../../shared/mosaic
+CLIBS     := -L${NETCDF_HOME}/lib -L${HDF5_HOME}/lib -lnetcdf -lhdf5_hl -lhdf5 -limf $(CLIBS2) $(STATIC)
+
+TARGETS  := make_hgrid make_hgrid_parallel
+
+SOURCES  := make_hgrid.c create_conformal_cubic_grid.c create_gnomonic_cubic_grid.c create_grid_from_file.c create_lonlat_grid.c
+SOURCES  += mpp_domain.c mpp_io.c tool_util.c
+SOURCES  += read_mosaic.c create_xgrid.c interp.c
+
+OBJECTS  := $(SOURCES:c=o)
+
+HEADERS = fre-nctools.mk ../shared/mpp.h  ../shared/mpp_domain.h  ../shared/mpp_io.h ../shared/tool_util.h   \
+          ../../shared/mosaic/constant.h ../../shared/mosaic/create_xgrid.h  \
+          ../../shared/mosaic/interp.h  ../../shared/mosaic/mosaic_util.h  \
+          ../../shared/mosaic/read_mosaic.h ./create_hgrid.h
+
+all: $(TARGETS)
+
+make_hgrid: $(OBJECTS) mosaic_util.o mpp.o
+	$(CC) -o $@ $^ $(CLIBS)
+
+make_hgrid_parallel: $(OBJECTS) mosaic_util_parallel.o mpp_parallel.o
+	$(MPICC) -o $@ $^ $(CLIBS)
+
+make_hgrid.o: make_hgrid.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -c $< 
+
+create_gnomonic_cubic_grid.o: create_gnomonic_cubic_grid.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -c $< 
+
+create_conformal_cubic_grid.o: create_conformal_cubic_grid.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -c $< 
+
+create_lonlat_grid.o: create_lonlat_grid.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -c $< 
+
+create_grid_from_file.o: create_grid_from_file.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -c $< 
+
+mosaic_util.o: ../../shared/mosaic/mosaic_util.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -c $< 
+
+mosaic_util_parallel.o: ../../shared/mosaic/mosaic_util.c $(HEADERS)
+	$(MPICC) -Duse_libMPI $(CFLAGS) $(INCLUDES) -o $@ -c $< 
+
+read_mosaic.o: ../../shared/mosaic/read_mosaic.c $(HEADERS)
+	$(CC) -Duse_netCDF $(CFLAGS) $(INCLUDES) -c $< 
+
+read_mosaic_parallel.o: ../../shared/mosaic/read_mosaic.c $(HEADERS)
+	$(MPICC) -Duse_libMPI -Duse_netCDF $(CFLAGS) $(INCLUDES) -o $@ -c $< 
+
+interp.o: ../../shared/mosaic/interp.c $(HEADERS)
+	$(CC) -Duse_netCDF $(CFLAGS) $(INCLUDES) -c $< 
+
+mpp_io.o: ../shared/mpp_io.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ -c $< 
+
+mpp_domain.o: ../shared/mpp_domain.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ -c $< 
+
+mpp.o: ../shared/mpp.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ -c $< 
+
+mpp_parallel.o: ../shared/mpp.c $(HEADERS)
+	$(MPICC) -Duse_libMPI $(CFLAGS) $(INCLUDES) -o $@ -c $< 
+
+tool_util.o: ../shared/tool_util.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ -c $< 
+
+create_xgrid.o: ../../shared/mosaic/create_xgrid.c $(HEADERS)
+	$(CC) $(CFLAGS_O2) $(INCLUDES) -c $< 
+
+%.o: %.c
+	$(CC) $(CFLAGS) $(INCLUDES) -c $<
+
+clean:
+	-rm -f *.o $(TARGETS)

--- a/sorc/fre-nctools.fd/tools/make_solo_mosaic/env.odin
+++ b/sorc/fre-nctools.fd/tools/make_solo_mosaic/env.odin
@@ -1,0 +1,7 @@
+CLIBS_SITE  := 
+CFLAGS_SITE := 
+
+# GFDL uses the mpicc wrapper and Intel icc
+MPICC    := cc
+CC       := icc
+NETCDF_HOME = $(NETCDF_DIR)

--- a/sorc/fre-nctools.fd/tools/make_solo_mosaic/env.stampede
+++ b/sorc/fre-nctools.fd/tools/make_solo_mosaic/env.stampede
@@ -1,0 +1,7 @@
+CLIBS_SITE  := 
+CFLAGS_SITE := 
+
+# GFDL uses the mpicc wrapper and Intel icc
+MPICC    := mpiicc
+CC       := icc
+NETCDF_HOME = $(NETCDF_DIR)

--- a/sorc/fre-nctools.fd/tools/make_solo_mosaic/fre-nctools.mk_odin
+++ b/sorc/fre-nctools.fd/tools/make_solo_mosaic/fre-nctools.mk_odin
@@ -1,0 +1,76 @@
+#
+# $Id: fre-nctools.mk,v 20.0 2013/12/14 00:33:52 fms Exp $
+# ------------------------------------------------------------------------------
+# FMS/FRE Project: Makefile to Build Regridding Executables
+# ------------------------------------------------------------------------------
+# afy    Ver   1.00  Initial version (Makefile, ver 17.0.4.2)       June 10
+# afy    Ver   1.01  Add rules to build MPI-based executable        June 10
+# afy    Ver   1.02  Simplified according to fre-nctools standards  June 10
+# ------------------------------------------------------------------------------
+# Copyright (C) NOAA Geophysical Fluid Dynamics Laboratory, 2009-2011
+# This program is distributed under the terms of the GNU General Public
+# License. See the file COPYING contained in this directory
+#
+# Designed and written by V. Balaji, Amy Langenhorst and Aleksey Yakovlev
+#
+include env.$(SITE)
+
+#CC       := icc
+CFLAGS   := -O3
+CFLAGS_O2:= -O2
+INCLUDES := -I${NETCDF_HOME}/include -I./ -I../shared -I../../shared/mosaic
+CLIBS     := -L${NETCDF_HOME}/lib -L${HDF5_HOME}/lib -lnetcdf -lhdf5_hl -lhdf5 -limf $(CLIBS2) $(STATIC)
+
+TARGETS  := make_solo_mosaic
+
+SOURCES  := make_solo_mosaic.c get_contact.c
+SOURCES  += mpp.c mpp_domain.c mpp_io.c tool_util.c
+SOURCES  += create_xgrid.c interp.c mosaic_util.c read_mosaic.c
+
+OBJECTS  := $(SOURCES:c=o)
+
+HEADERS = fre-nctools.mk ../shared/mpp.h  ../shared/mpp_domain.h  ../shared/mpp_io.h ../shared/tool_util.h   \
+          ../../shared/mosaic/constant.h ../../shared/mosaic/create_xgrid.h  \
+          ../../shared/mosaic/interp.h  ../../shared/mosaic/mosaic_util.h  \
+          ./get_contact.h ../../shared/mosaic/read_mosaic.h
+
+all: $(TARGETS)
+
+make_solo_mosaic: $(OBJECTS)
+	$(CC) -o $@ $^ $(CLIBS)
+
+make_solo_mosaic.o: make_solo_mosaic.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -c $< 
+
+get_contact.o: get_contact.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -c $< 
+
+mosaic_util.o: ../../shared/mosaic/mosaic_util.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -c $< 
+
+read_mosaic.o: ../../shared/mosaic/read_mosaic.c $(HEADERS)
+	$(CC) -Duse_netCDF $(CFLAGS) $(INCLUDES) -c $< 
+
+interp.o: ../../shared/mosaic/interp.c $(HEADERS)
+	$(CC) -Duse_netCDF $(CFLAGS) $(INCLUDES) -c $< 
+
+mpp_io.o: ../shared/mpp_io.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ -c $< 
+
+mpp_domain.o: ../shared/mpp_domain.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ -c $< 
+
+mpp.o: ../shared/mpp.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ -c $< 
+
+tool_util.o: ../shared/tool_util.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ -c $< 
+
+create_xgrid.o: ../../shared/mosaic/create_xgrid.c $(HEADERS)
+	$(CC) $(CFLAGS_O2) $(INCLUDES) -c $< 
+
+%.o: %.c
+	$(CC) $(CFLAGS) $(INCLUDES) -c $<
+
+clean:
+	-rm -f *.o $(TARGETS)

--- a/sorc/fre-nctools.fd/tools/make_solo_mosaic/fre-nctools.mk_stampede
+++ b/sorc/fre-nctools.fd/tools/make_solo_mosaic/fre-nctools.mk_stampede
@@ -1,0 +1,76 @@
+#
+# $Id: fre-nctools.mk,v 20.0 2013/12/14 00:33:52 fms Exp $
+# ------------------------------------------------------------------------------
+# FMS/FRE Project: Makefile to Build Regridding Executables
+# ------------------------------------------------------------------------------
+# afy    Ver   1.00  Initial version (Makefile, ver 17.0.4.2)       June 10
+# afy    Ver   1.01  Add rules to build MPI-based executable        June 10
+# afy    Ver   1.02  Simplified according to fre-nctools standards  June 10
+# ------------------------------------------------------------------------------
+# Copyright (C) NOAA Geophysical Fluid Dynamics Laboratory, 2009-2011
+# This program is distributed under the terms of the GNU General Public
+# License. See the file COPYING contained in this directory
+#
+# Designed and written by V. Balaji, Amy Langenhorst and Aleksey Yakovlev
+#
+include env.$(SITE)
+
+#CC       := icc
+CFLAGS   := -O3
+CFLAGS_O2:= -O2
+INCLUDES := -I${NETCDF_HOME}/include -I./ -I../shared -I../../shared/mosaic
+CLIBS     := -L${NETCDF_HOME}/lib -L${HDF5_HOME}/lib -lnetcdf -lhdf5_hl -lhdf5 -limf $(CLIBS2) $(STATIC)
+
+TARGETS  := make_solo_mosaic
+
+SOURCES  := make_solo_mosaic.c get_contact.c
+SOURCES  += mpp.c mpp_domain.c mpp_io.c tool_util.c
+SOURCES  += create_xgrid.c interp.c mosaic_util.c read_mosaic.c
+
+OBJECTS  := $(SOURCES:c=o)
+
+HEADERS = fre-nctools.mk ../shared/mpp.h  ../shared/mpp_domain.h  ../shared/mpp_io.h ../shared/tool_util.h   \
+          ../../shared/mosaic/constant.h ../../shared/mosaic/create_xgrid.h  \
+          ../../shared/mosaic/interp.h  ../../shared/mosaic/mosaic_util.h  \
+          ./get_contact.h ../../shared/mosaic/read_mosaic.h
+
+all: $(TARGETS)
+
+make_solo_mosaic: $(OBJECTS)
+	$(CC) -o $@ $^ $(CLIBS)
+
+make_solo_mosaic.o: make_solo_mosaic.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -c $< 
+
+get_contact.o: get_contact.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -c $< 
+
+mosaic_util.o: ../../shared/mosaic/mosaic_util.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -c $< 
+
+read_mosaic.o: ../../shared/mosaic/read_mosaic.c $(HEADERS)
+	$(CC) -Duse_netCDF $(CFLAGS) $(INCLUDES) -c $< 
+
+interp.o: ../../shared/mosaic/interp.c $(HEADERS)
+	$(CC) -Duse_netCDF $(CFLAGS) $(INCLUDES) -c $< 
+
+mpp_io.o: ../shared/mpp_io.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ -c $< 
+
+mpp_domain.o: ../shared/mpp_domain.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ -c $< 
+
+mpp.o: ../shared/mpp.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ -c $< 
+
+tool_util.o: ../shared/tool_util.c $(HEADERS)
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ -c $< 
+
+create_xgrid.o: ../../shared/mosaic/create_xgrid.c $(HEADERS)
+	$(CC) $(CFLAGS_O2) $(INCLUDES) -c $< 
+
+%.o: %.c
+	$(CC) $(CFLAGS) $(INCLUDES) -c $<
+
+clean:
+	-rm -f *.o $(TARGETS)

--- a/sorc/fre-nctools.fd/tools/shave.fd/build_shave
+++ b/sorc/fre-nctools.fd/tools/shave.fd/build_shave
@@ -21,6 +21,9 @@ case $1 in
   "cheyenne" )
      FCMP=ifort
      FFLAGS="-O3 -fp-model precise -I$NETCDF/include -L$NETCDF/lib -lnetcdff -lnetcdf" ;;
+  "odin" )
+     FCMP=ftn
+     FFLAGS="-O3 -fp-model precise -I$NETCDF/include -L$NETCDF/lib -lnetcdff -lnetcdf" ;;
   *)
      echo "SHAVE UTILITY BUILD NOT TESTED ON MACHINE $1"
      exit 1 ;;

--- a/sorc/fre-nctools.fd/tools/shave.fd/build_shave
+++ b/sorc/fre-nctools.fd/tools/shave.fd/build_shave
@@ -24,6 +24,10 @@ case $1 in
   "odin" )
      FCMP=ftn
      FFLAGS="-O3 -fp-model precise -I$NETCDF/include -L$NETCDF/lib -lnetcdff -lnetcdf" ;;
+  "stampede" )
+     FCMP=ifort
+     NETCDF=${TACC_NETCDF_DIR}
+     FFLAGS="-O3 -fp-model precise -I$NETCDF/include -L$NETCDF/lib -lnetcdff -lnetcdf" ;;
   *)
      echo "SHAVE UTILITY BUILD NOT TESTED ON MACHINE $1"
      exit 1 ;;

--- a/sorc/machine-setup.sh
+++ b/sorc/machine-setup.sh
@@ -109,6 +109,15 @@ elif [[ -d /lustre && -d /ncrc ]] ; then
     fi
     target=gaea
     module purge
+elif [[ "$(hostname)" =~ "Orion" ]]; then
+    target="orion"
+    module purge
+elif [[ "$(hostname)" =~ "odin" ]]; then
+    target="odin"
+
+elif [[ -d /work/00315 && -d /scratch/00315 ]] ; then
+    target=stampede
+    module purge
 else
     echo WARNING: UNKNOWN PLATFORM 1>&2
 fi


### PR DESCRIPTION
Add building supports on Odin and Stampede. 

Only tested three build scripts, _build_orog.sh_, _build_fre-nctools.sh_ and _build_sfc_climo_gen.sh_, which are the ones used in SRW application.