### PR TITLE
Feature/chgres grib2 odinstampede

### DIFF
--- a/modulefiles/chgres_cube.odin
+++ b/modulefiles/chgres_cube.odin
@@ -2,12 +2,17 @@
 ## chgres build module for Odin
 #############################################################
 
-module use /oldscratch/ywang/external/modulefiles
-module load esmf/8.0.0bs30
-
+module load PrgEnv-intel
+module swap intel/19.0.5.281
+module load cray-mpich/7.7.10
+module load cray-libsci
 module load cray-netcdf-hdf5parallel
 module load cray-parallel-netcdf
 module load cray-hdf5-parallel
+
+module use /oldscratch/ywang/external/modulefiles
+module load esmf/8.0.0
+
 module load w3nco/v2.0.6
 module load nemsio/v2.2.2
 module load bacio/v2.0.2
@@ -24,4 +29,5 @@ export WGRIB2_LIB="/home/larissa.reames/tmp/wgrib2-2/grib2/lib/libwgrib2.a"
 
 
 # for debugging
-#export FFLAGS="-O0 -g -traceback -r8 -i4 -qopenmp -convert big_endian -check bounds -warn unused -assume byterecl"
+# #export FFLAGS="-O0 -g -traceback -r8 -i4 -qopenmp -convert big_endian -check bounds -warn unused -assume byterecl"
+#

--- a/modulefiles/chgres_cube.odin
+++ b/modulefiles/chgres_cube.odin
@@ -2,6 +2,8 @@
 ## chgres build module for Odin
 #############################################################
 
+module load craype/2.6.2
+module load craype-ivybridge
 module load PrgEnv-intel
 module swap intel/19.0.5.281
 module load cray-mpich/7.7.10

--- a/modulefiles/chgres_cube.stampede
+++ b/modulefiles/chgres_cube.stampede
@@ -1,0 +1,31 @@
+#%Module#####################################################
+## chgres build module for Odin
+#############################################################
+
+module purge
+
+module load intel/18.0.2
+module load impi/18.0.2
+module load phdf5/1.10.4
+module load parallel-netcdf/4.6.2
+
+module use /work/00315/tg455890/stampede2/external/modulefiles
+module load esmf/8.0.0
+
+module load w3nco/v2.0.6
+module load nemsio/v2.2.3
+module load bacio/v2.0.2
+module load sp/v2.0.2
+module load sfcio/v1.0.0
+module load sigio/v2.1.0
+
+
+export FCOMP=mpiifort
+export FFLAGS="-O3 -fp-model precise -g -traceback -r8 -i4 -qopenmp -convert big_endian -assume byterecl"
+export WGRIB2API_LIB="/work/00315/tg455890/stampede2/external/NWPROD_LIB/wgrib2.v2_0_8/lib/libwgrib2_api.a"
+export WGRIB2API_INC="/work/00315/tg455890/stampede2/external/NWPROD_LIB/wgrib2.v2_0_8/include"
+export WGRIB2_LIB="/work/00315/tg455890/stampede2/external/NWPROD_LIB/wgrib2.v2_0_8/lib/libwgrib2.a"
+
+
+# for debugging
+#export FFLAGS="-O0 -g -traceback -r8 -i4 -qopenmp -convert big_endian -check bounds -warn unused -assume byterecl"

--- a/sorc/chgres_cube.fd/Makefile
+++ b/sorc/chgres_cube.fd/Makefile
@@ -9,7 +9,7 @@ $(info ESMFMKFILE = "$(ESMFMKFILE)")
 $(info )
 include $(ESMFMKFILE)
 #
-# Print out variables defined in the file ESMFMKFILE (included above) 
+# Print out variables defined in the file ESMFMKFILE (included above)
 # and used in the link step below.
 #
 $(info )
@@ -23,7 +23,7 @@ $(info WGRIB2_LIB = "$(WGRIB2_LIB)")
 $(info WGRIB2API_LIB = "$(WGRIB2API_LIB)")
 $(info )
 #
-# Full paths to static library files. 
+# Full paths to static library files.
 #
 LIBS = $(NEMSIO_LIB) \
        $(W3NCO_LIBd) \
@@ -32,8 +32,8 @@ LIBS = $(NEMSIO_LIB) \
        $(SIGIO_LIB4) \
        $(SFCIO_LIB4)
 
-# If we can build wgrib2 on theia so that its static library does not 
-# include NetCDF, then we can include WGRIB2_LIB and WGRIB2API_LIB as 
+# If we can build wgrib2 on theia so that its static library does not
+# include NetCDF, then we can include WGRIB2_LIB and WGRIB2API_LIB as
 # part of the LIBS variable.  Otherwise, they will have to be added se-
 # parately at the end of the build command below (as is currently done).
 #        $(WGRIB2API_LIB) \
@@ -46,7 +46,7 @@ LIBS = $(NEMSIO_LIB) \
 INCS = -I$(NEMSIO_INC) \
        -I$(WGRIB2API_INC) \
        -I$(SFCIO_INC4) \
-       -I$(SIGIO_INC4) 
+       -I$(SIGIO_INC4)
 
 CMD = chgres_cube.exe
 
@@ -65,8 +65,8 @@ OBJS = chgres.o \
 #
 # Fortran compiler and compilation flags.
 #
-FCOMP = mpiifort
-FFLAGS = -O0 -g -traceback -r8 -i4 -qopenmp -convert big_endian \
+FCOMP  ?= mpiifort
+FFLAGS ?= -O0 -g -traceback -r8 -i4 -qopenmp -convert big_endian \
          -check bounds -warn unused -assume byterecl
 #ESMF_F90ESMFLINKLIBS = -lesmf -cxxlib -lrt -ldl -lnetcdff -lnetcdf
 #ESMF_F90ESMFLINKLIBS = -lesmf -cxxlib -lrt -ldl -lnetcdff
@@ -82,7 +82,7 @@ $(CMD):	$(OBJS)
 	  $(ESMF_F90ESMFLINKRPATHS) \
 	  $(ESMF_F90ESMFLINKLIBS) \
 	  $(WGRIB2_LIB) \
-	  $(WGRIB2API_LIB) 
+	  $(WGRIB2API_LIB)
 
 # We may be able to remove the above two lines involving WGRIB2_LIB and
 # WGRIB2API_LIB if these can be made part of the definition of the vari-

--- a/sorc/machine-setup.sh
+++ b/sorc/machine-setup.sh
@@ -109,6 +109,10 @@ elif [[ -d /lustre && -d /ncrc ]] ; then
     fi
     target=gaea
     module purge
+elif [[ -d /scratch/wof ]] ; then
+    target=odin
+elif [[ -d /work/00315/ ]] ; then
+    target=stampede
 elif [[ -d /Applications ]] ; then
     # We are on a MacOSX system, nothing to do
     echo "Platform: MacOSX"


### PR DESCRIPTION
- Added building supports on Odin and on Stampede to branch "feature/chgres_grib2".
- One significant change is these two lines in _sorc/chgres_cube.fd/Makefile_

```
FCOMP  ?= mpiifort
FFLAGS ?= -O0 -g -traceback -r8 -i4 -qopenmp -convert big_endian \
         -check bounds -warn unused -assume byterecl
```
and the original lines are

```
FCOMP  = mpiifort
FFLAGS = -O0 -g -traceback -r8 -i4 -qopenmp -convert big_endian \
         -check bounds -warn unused -assume byterecl
```

I made this change because I found even variables _FCOMP_ & _FFLAGS_ are defined in the module files, for examples, _modulefiles/chgres_cube.hera_ and _modulefiles/chgres_cube.jet_ etc., they are not used  in the Makefile. It is a fault error for a Cray machine because Cray compiler uses _ftn_ instead of _mpiifort_ for program compiling.

The change will let the variables (_FCOMP_ & _FFLAGS_) in file _sorc/chgres_cube.fd/Makefile_ to pick up whatever values of the same environment variables if they are defined. Otherwise, they will use the default values in the Makefile (the original behavior).