### PR TITLE
Update (roll back) version of ESMF used by chgres_cube on hera.  

### DIFF
--- a/modulefiles/chgres_cube.hera
+++ b/modulefiles/chgres_cube.hera
@@ -7,7 +7,7 @@ module load impi/2018.0.4
 module load netcdf/4.6.1
 
 module use /scratch1/NCEPDEV/nems/emc.nemspara/soft/modulefiles
-module load esmf/8.0.0bs21
+module load esmf/8.0.0
 
 module use -a /scratch2/NCEPDEV/nwprod/NCEPLIBS/modulefiles
 module load w3nco


### PR DESCRIPTION
## Description of Changes
This is necessary because the previously used version of ESMF (8.0.0bs21) was modified (by the hera admins or EMC) so that it breaks the regional_workflow (the make_ics task fails).  Thus, we roll back the version of ESMF to something slightly earlier (8.0.0).

## Tests Conducted
Built chgres_cube with the updated version on hera and ran the workflow (all WE2E tests).  It now works.

## Other Notes
Once this is accepted, the hash # in the Externals.cfg file of the ufs-srweather-app (master branch), stanza [ufs_utils_chgres] needs to be updated to the new hash created by this PR.