### PR TITLE
Make size of mosaic_name string in make_solo_mosaic longer

### DIFF
--- a/sorc/fre-nctools.fd/tools/make_solo_mosaic/make_solo_mosaic.c
+++ b/sorc/fre-nctools.fd/tools/make_solo_mosaic/make_solo_mosaic.c
@@ -78,7 +78,7 @@ main (int argc, char *argv[])
   int contact_tile1_jstart[MAXCONTACT], contact_tile1_jend[MAXCONTACT];
   int contact_tile2_istart[MAXCONTACT], contact_tile2_iend[MAXCONTACT];
   int contact_tile2_jstart[MAXCONTACT], contact_tile2_jend[MAXCONTACT];
-  char mosaic_name[128] = "solo_mosaic";
+  char mosaic_name[STRING] = "solo_mosaic";
   char grid_descriptor[128] = "";
   int c, i, n, m, l, errflg;
   


### PR DESCRIPTION
Change the length of the string mosaic_name in make_solo_mosaic.c from just 128 characters to STRING=255 characters.

This is needed because the way make_solo_mosaic is called in regional_workflow, mosaic_name includes not only the basename of the mosaic file but also the absolute path to it, and that path can get longer than 128 characters.  In that case, make_solo_mosaic fails (without a clear error message).  It would be even better to make mosaic_name a variable length string, but I don't remember how to do that in c.  This suffices for now.

I tested this with ~25 different tests in regional_workflow with varying mosaic_name lengths, and they all passed (whereas some of them failed previously with only a 128 character mosaic_name).  